### PR TITLE
Make warthog spawn on dirt with dry grass

### DIFF
--- a/warthog.lua
+++ b/warthog.lua
@@ -48,7 +48,7 @@ mobs:register_mob("mobs:pumba", {
 	end,
 })
 
-mobs:register_spawn("mobs:pumba", {"ethereal:mushroom_dirt"}, 20, 10, 15000, 1, 31000)
+mobs:register_spawn("mobs:pumba", {"ethereal:mushroom_dirt", "default:dirt_with_dry_grass"}, 20, 10, 15000, 1, 31000)
 
 mobs:register_egg("mobs:pumba", "Warthog", "wool_pink.png", 1)
 


### PR DESCRIPTION
Pumba should like savannah; this way it can spawn on the ground of this new biome, that's included into V7's defaults, even outside ethereal worlds.